### PR TITLE
Add a Dockerfile, for fun and profit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:14.04
+RUN apt-get update
+RUN apt-get install -y default-jdk
+RUN apt-get install -y maven2
+COPY ./Java/ /src/
+WORKDIR /src/
+RUN ant
+ENTRYPOINT ["java", "-classpath", "/src/build/airplay.jar:/src/lib/jmdns.jar", "com.jameslow.AirPlay"]


### PR DESCRIPTION
This allows to build Open AirPlay in a container (and to execute it!).

The container will have to be started with a bunch of extra options to share X socket access and multicast network, though.